### PR TITLE
Only filter on status if present

### DIFF
--- a/src/com/github/emilbayes/downloadmanager/DownloadManagerPlugin.java
+++ b/src/com/github/emilbayes/downloadmanager/DownloadManagerPlugin.java
@@ -19,12 +19,6 @@ import android.app.DownloadManager;
 import java.util.HashMap;
 import java.util.Map;
 
-import static android.app.DownloadManager.STATUS_FAILED;
-import static android.app.DownloadManager.STATUS_PAUSED;
-import static android.app.DownloadManager.STATUS_PENDING;
-import static android.app.DownloadManager.STATUS_RUNNING;
-import static android.app.DownloadManager.STATUS_SUCCESSFUL;
-
 public class DownloadManagerPlugin extends CordovaPlugin {
     DownloadManager downloadManager;
 
@@ -113,7 +107,9 @@ public class DownloadManagerPlugin extends CordovaPlugin {
         long[] ids = longsFromJSON(obj.optJSONArray("ids"));
         query.setFilterById(ids);
 
-        query.setFilterByStatus(obj.optInt("status", STATUS_FAILED | STATUS_PAUSED | STATUS_PENDING | STATUS_RUNNING | STATUS_SUCCESSFUL));
+        if (obj.has("status")) {
+            query.setFilterByStatus(obj.getInt("status"));
+        }
 
         return query;
     }


### PR DESCRIPTION
There is some weird behaviour in the DownloadManager if you set both the IDs and status filter, the IDs filter does not have any effect, and you get all the downloads with given status.

I don't think this is a breaking change, leaving out the IDs filter will give you all the downloads as before.